### PR TITLE
Migrate to ab_glyph

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,4 +19,4 @@ keywords = ["image","text","imageproc"]
 [dependencies]
 ab_glyph = "0.2.30"
 image = "0.25.6"
-imageproc = "0.25.0"
+imageproc = "0.26.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,6 +17,6 @@ keywords = ["image","text","imageproc"]
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-ab_glyph = "0.2.29"
+ab_glyph = "0.2.30"
 image = "0.25.6"
 imageproc = "0.25.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 name = "text_on_image"
 version = "0.1.0"
 authors = ["Wyatt Bowen"]
-edition = "2021"
+edition = "2024"
 
 readme = "README.md"
 description = "An easier way to place text on images."
@@ -17,6 +17,6 @@ keywords = ["image","text","imageproc"]
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-image = "0.24.8"
-imageproc = "0.23.0"
-rusttype = "0.9.3"
+ab_glyph = "0.2.29"
+image = "0.25.6"
+imageproc = "0.25.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,4 +19,4 @@ keywords = ["image","text","imageproc"]
 [dependencies]
 ab_glyph = "0.2.30"
 image = "0.25.6"
-imageproc = "0.26.0"
+imageproc = "0.27.0"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -135,12 +135,14 @@ pub fn text_on_image<T: AsRef<str>>(
             for &line in &lines {
                 let mut buffer: String = String::new();
                 for word in line.split_whitespace() {
+                    let buffer_copy = buffer.clone();
+                    let buffer_width = get_text_width(font_bundle, buffer_copy.as_str());
+                    let space_word = String::from(" ") + word;
+                    let buffer_space_word_width =
+                        buffer_width + get_text_width(font_bundle, space_word.as_str());
                     if cfg!(debug_assertions) {
                         println!(
-                            "\"{}\" has width {}. Compare to max_width {}",
-                            buffer.clone() + " " + word,
-                            get_text_width(font_bundle, buffer.clone() + " " + word),
-                            max_width
+                            "\"{buffer_copy} {word}\" has width {buffer_space_word_width}. Compare to max_width {max_width}"
                         );
                     }
                     let optional_space_width: u32 = if buffer.is_empty() {
@@ -148,48 +150,46 @@ pub fn text_on_image<T: AsRef<str>>(
                     } else {
                         0
                     };
-                    if get_text_width(font_bundle, buffer.clone() + " " + word)
-                        <= max_width + optional_space_width
-                    {
-                        //Add word to line
+                    if buffer_space_word_width <= max_width + optional_space_width {
+                        // Add word to line
                         if cfg!(debug_assertions) {
                             println!("Word {word} gets added to line");
                         }
                         if buffer.is_empty() {
-                            buffer += word;
+                            buffer.push_str(word);
                         } else {
-                            buffer = buffer + " " + word;
+                            buffer.push_str(space_word.as_str());
                         }
-                    } else if get_text_width(font_bundle, buffer.clone() + " " + word) > *max_width
-                        && buffer.is_empty()
-                    {
-                        //add partial word with a dash at the end
+                    } else if buffer_space_word_width > *max_width && buffer.is_empty() {
+                        // Add partial word with a dash at the end
                         let word_chars = word.chars();
                         for word_char in word_chars {
-                            if get_text_width(font_bundle, buffer.clone() + "-") <= *max_width {
+                            if (get_text_width(font_bundle, buffer.as_str())
+                                + get_text_width(font_bundle, "-"))
+                                <= *max_width
+                            {
                                 buffer.push(word_char);
                             } else {
                                 buffer.push('-');
                                 lines_altered.push(buffer);
-                                buffer = String::new();
-                                buffer.push(word_char);
+                                buffer = String::from(word_char);
                             }
                         }
-                    } else if get_text_width(font_bundle, buffer.clone() + " " + word) > *max_width
-                        && !buffer.is_empty()
-                    {
+                    } else if buffer_space_word_width > *max_width && !buffer.is_empty() {
                         if cfg!(debug_assertions) {
                             println!("Word {word} goes over max width && buffer is not empty.");
                         }
-                        //write buffer to lines_altered, empty buffer, evaluate as new line
+                        // Write buffer to lines_altered, empty buffer, evaluate as new line
                         lines_altered.push(buffer);
                         buffer = String::new();
                         let word_chars = word.chars();
                         for word_char in word_chars {
-                            if get_text_width(font_bundle, buffer.clone() + "-") <= *max_width {
+                            if (get_text_width(font_bundle, buffer.as_str())
+                                + get_text_width(font_bundle, "-"))
+                                <= *max_width
+                            {
                                 buffer.push(word_char);
                             } else {
-                                buffer += "-";
                                 lines_altered.push(buffer);
                                 buffer = String::new();
                             }
@@ -222,8 +222,8 @@ fn get_text_width<T: AsRef<str>>(font_bundle: &FontBundle, text: T) -> u32 {
 
 /// Helper function to get text height.
 fn get_text_height(font_bundle: &FontBundle) -> i32 {
-    let v_metrics = font_bundle.font.as_scaled(font_bundle.scale);
-    (v_metrics.ascent() - v_metrics.descent() + v_metrics.line_gap()) as i32
+    let scaled_font = font_bundle.font.as_scaled(font_bundle.scale);
+    (scaled_font.ascent() - scaled_font.descent() + scaled_font.line_gap()) as i32
 }
 
 #[allow(clippy::too_many_arguments)]
@@ -268,7 +268,7 @@ fn position_and_draw(
     let lines_len = lines.len().cast_signed() as i32;
     for (i, &line) in lines.iter().enumerate() {
         if cfg!(debug_assertions) {
-            println!("{} width: {}", line, get_text_width(font_bundle, line));
+            println!("{line} width: {}", get_text_width(font_bundle, line));
         }
         let current_line = i.cast_signed() as i32;
         let vertical_offset: i32 = match vertical_anchor {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -11,7 +11,7 @@ use image::{DynamicImage, ImageError};
 use imageproc::drawing::{draw_text_mut, text_size};
 
 pub use ab_glyph::{FontRef, PxScale};
-pub use image::Rgba;
+pub use image::{Rgba, open};
 
 #[derive(Debug)]
 pub enum TextOnImageError {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,10 +1,14 @@
-//! A library to make placing text on images easier. Extends draw_text_mut's functionality from [imageproc](https://docs.rs/imageproc/0.23.0/imageproc/index.html).
+#![warn(clippy::pedantic)]
+#![allow(clippy::must_use_candidate)]
+#![allow(clippy::cast_possible_truncation)]
+
+//! A library to make placing text on images easier. Extends the functionality of the [draw_text_mut](https://docs.rs/imageproc/0.23.0/imageproc/drawing/fn.draw_text_mut.html) function from [imageproc](https://docs.rs/imageproc/0.23.0/imageproc/index.html).
 
 use std::fmt::Display;
 
+use ab_glyph::{Font, FontRef, PxScale, ScaleFont};
 use image::{DynamicImage, ImageError, Rgba};
-use imageproc::drawing::draw_text_mut;
-use rusttype::{point, Font, Scale};
+use imageproc::drawing::{draw_text_mut, text_size};
 
 #[derive(Debug)]
 pub enum TextOnImageError {
@@ -42,10 +46,10 @@ impl WrapBehavior {
     }
 }
 
-/// A bundle of font related values.
+/// A bundle of font-related values.
 pub struct FontBundle<'a> {
-    font: &'a Font<'a>,
-    scale: Scale,
+    font: &'a FontRef<'a>,
+    scale: PxScale,
     color: Rgba<u8>,
 }
 
@@ -60,10 +64,14 @@ impl Display for FontBundle<'_> {
 }
 
 impl<'a> FontBundle<'a> {
-    pub fn new(font_: &'a Font<'a>, scale_: Scale, color_: Rgba<u8>) -> Self {
-        if scale_.x <= 0. || scale_.y <= 0. {
-            panic!("text_on_image: FontBundle scale.x or scale.y cannot be <= 0.0!");
-        }
+    /// # Panics
+    ///
+    /// Will panic if [`FontBundle`] `scale.x` or `scale.y` is negative
+    pub fn new(font_: &'a FontRef<'a>, scale_: PxScale, color_: Rgba<u8>) -> Self {
+        assert!(
+            !(scale_.x <= 0. || scale_.y <= 0.),
+            "text_on_image: FontBundle scale.x or scale.y cannot be <= 0.0!"
+        );
         FontBundle {
             font: font_,
             scale: scale_,
@@ -71,10 +79,14 @@ impl<'a> FontBundle<'a> {
         }
     }
 
-    pub fn set_scale(&mut self, scale_: Scale) {
-        if scale_.x <= 0. || scale_.y <= 0. {
-            panic!("text_on_image: FontBundle scale.x or scale.y cannot be <= 0.0!");
-        }
+    /// # Panics
+    ///
+    /// Will panic if [`FontBundle`] `scale.x` or `scale.y` is negative
+    pub fn set_scale(&mut self, scale_: PxScale) {
+        assert!(
+            !(scale_.x <= 0. || scale_.y <= 0.),
+            "text_on_image: FontBundle scale.x or scale.y cannot be <= 0.0!"
+        );
         self.scale = scale_;
     }
 
@@ -83,22 +95,27 @@ impl<'a> FontBundle<'a> {
     }
 }
 
+#[allow(clippy::too_many_arguments)]
 /// Draws text on an image with support for text jusification, vertical anchor, and line wrapping.
+///
+/// # Panics
+///
+/// Will panic if [`WrapBehavior::Wrap`] `max_width` is below 2 em
 pub fn text_on_image<T: AsRef<str>>(
     image: &mut DynamicImage,
     text: T,
     font_bundle: &FontBundle<'_>,
     pixels_from_left: i32,
     pixels_from_top: i32,
-    horizontal_justify: TextJustify,
-    vertical_anchor: VerticalAnchor,
-    wrap_behavior: WrapBehavior,
+    horizontal_justify: &TextJustify,
+    vertical_anchor: &VerticalAnchor,
+    wrap_behavior: &WrapBehavior,
 ) {
-    let lines: Vec<&str> = text.as_ref().lines().map(|line| line.trim()).collect();
+    let lines: Vec<&str> = text.as_ref().lines().map(str::trim).collect();
     match wrap_behavior {
         WrapBehavior::NoWrap => position_and_draw(
             image,
-            lines,
+            &lines,
             font_bundle,
             pixels_from_left,
             pixels_from_top,
@@ -106,9 +123,11 @@ pub fn text_on_image<T: AsRef<str>>(
             vertical_anchor,
         ),
         WrapBehavior::Wrap(max_width) => {
-            if max_width < get_text_width(font_bundle, "mm") {
-                panic!("text_on_image: Cannot set max_width for wrapping below 2 ems! Try setting max_width to at least {}", get_text_width(font_bundle, "mm"));
-            }
+            assert!(
+                (max_width >= &get_text_width(font_bundle, "mm")),
+                "text_on_image: Cannot set max_width for wrapping below 2 ems! Try setting max_width to at least {}",
+                get_text_width(font_bundle, "mm")
+            );
             let mut lines_altered: Vec<String> = vec![];
             for &line in &lines {
                 let mut buffer: String = String::new();
@@ -131,41 +150,41 @@ pub fn text_on_image<T: AsRef<str>>(
                     {
                         //Add word to line
                         if cfg!(debug_assertions) {
-                            println!("Word {} gets added to line", word);
+                            println!("Word {word} gets added to line");
                         }
                         if buffer.is_empty() {
                             buffer += word;
                         } else {
                             buffer = buffer + " " + word;
                         }
-                    } else if get_text_width(font_bundle, buffer.clone() + " " + word) > max_width
+                    } else if get_text_width(font_bundle, buffer.clone() + " " + word) > *max_width
                         && buffer.is_empty()
                     {
                         //add partial word with a dash at the end
                         let word_chars = word.chars();
                         for word_char in word_chars {
-                            if get_text_width(font_bundle, buffer.clone() + "-") <= max_width {
-                                buffer = buffer + &word_char.to_string();
+                            if get_text_width(font_bundle, buffer.clone() + "-") <= *max_width {
+                                buffer.push(word_char);
                             } else {
-                                buffer += "-";
+                                buffer.push('-');
                                 lines_altered.push(buffer);
                                 buffer = String::new();
-                                buffer = buffer + &word_char.to_string();
+                                buffer.push(word_char);
                             }
                         }
-                    } else if get_text_width(font_bundle, buffer.clone() + " " + word) > max_width
+                    } else if get_text_width(font_bundle, buffer.clone() + " " + word) > *max_width
                         && !buffer.is_empty()
                     {
                         if cfg!(debug_assertions) {
-                            println!("Word {} goes over max width && buffer is not empty.", word);
+                            println!("Word {word} goes over max width && buffer is not empty.");
                         }
                         //write buffer to lines_altered, empty buffer, evaluate as new line
                         lines_altered.push(buffer);
                         buffer = String::new();
                         let word_chars = word.chars();
                         for word_char in word_chars {
-                            if get_text_width(font_bundle, buffer.clone() + "-") <= max_width {
-                                buffer = buffer + &word_char.to_string();
+                            if get_text_width(font_bundle, buffer.clone() + "-") <= *max_width {
+                                buffer.push(word_char);
                             } else {
                                 buffer += "-";
                                 lines_altered.push(buffer);
@@ -176,39 +195,35 @@ pub fn text_on_image<T: AsRef<str>>(
                 }
                 lines_altered.push(buffer);
             }
-            let lines_altered: Vec<&str> = lines_altered.iter().map(|line| line.as_str()).collect();
+            let lines_altered: Vec<&str> = lines_altered.iter().map(String::as_str).collect();
             if cfg!(debug_assertions) {
-                println!("Lines altered:\n{:?}", lines_altered);
+                println!("Lines altered:\n{lines_altered:?}");
             }
             position_and_draw(
                 image,
-                lines_altered,
+                &lines_altered,
                 font_bundle,
                 pixels_from_left,
                 pixels_from_top,
                 horizontal_justify,
                 vertical_anchor,
-            )
+            );
         }
     }
 }
 
 /// Helper function to get text width.
 fn get_text_width<T: AsRef<str>>(font_bundle: &FontBundle, text: T) -> u32 {
-    font_bundle
-        .font
-        .layout(text.as_ref(), font_bundle.scale, point(0., 0.))
-        .map(|glyph| glyph.position().x + glyph.unpositioned().h_metrics().advance_width)
-        .last()
-        .unwrap_or(0.) as u32
+    text_size(font_bundle.scale, &font_bundle.font, text.as_ref()).0
 }
 
 /// Helper function to get text height.
 fn get_text_height(font_bundle: &FontBundle) -> i32 {
-    let v_metrics = font_bundle.font.v_metrics(font_bundle.scale);
-    (v_metrics.ascent - v_metrics.descent + v_metrics.line_gap) as i32
+    let v_metrics = font_bundle.font.as_scaled(font_bundle.scale);
+    (v_metrics.ascent() - v_metrics.descent() + v_metrics.line_gap()) as i32
 }
 
+#[allow(clippy::too_many_arguments)]
 /// Draws text on an image with a small cross where the coordinates are.
 pub fn text_on_image_draw_debug<T: AsRef<str>>(
     image: &mut DynamicImage,
@@ -216,9 +231,9 @@ pub fn text_on_image_draw_debug<T: AsRef<str>>(
     font_bundle: &FontBundle<'_>,
     pixels_from_left: i32,
     pixels_from_top: i32,
-    horizontal_justify: TextJustify,
-    vertical_justify: VerticalAnchor,
-    wrap_behavior: WrapBehavior,
+    horizontal_justify: &TextJustify,
+    vertical_justify: &VerticalAnchor,
+    wrap_behavior: &WrapBehavior,
 ) {
     imageproc::drawing::draw_cross_mut(
         image,
@@ -240,20 +255,20 @@ pub fn text_on_image_draw_debug<T: AsRef<str>>(
 
 fn position_and_draw(
     image: &mut DynamicImage,
-    lines: Vec<&str>,
+    lines: &[&str],
     font_bundle: &FontBundle<'_>,
     pixels_from_left: i32,
     pixels_from_top: i32,
-    horizontal_justify: TextJustify,
-    vertical_anchor: VerticalAnchor,
+    horizontal_justify: &TextJustify,
+    vertical_anchor: &VerticalAnchor,
 ) {
-    let lines_len = lines.len() as i32;
-    let mut current_line = 0;
-    for &line in &lines {
+    let lines_len = lines.len().cast_signed() as i32;
+    for (i, &line) in lines.iter().enumerate() {
         if cfg!(debug_assertions) {
             println!("{} width: {}", line, get_text_width(font_bundle, line));
         }
-        let vertical_offset = match vertical_anchor {
+        let current_line = i.cast_signed() as i32;
+        let vertical_offset: i32 = match vertical_anchor {
             VerticalAnchor::Top => get_text_height(font_bundle) * current_line,
             VerticalAnchor::Center => {
                 (get_text_height(font_bundle) * current_line
@@ -270,16 +285,15 @@ fn position_and_draw(
         draw_text_mut(
             image,
             font_bundle.color,
-            pixels_from_left - horizontal_offset as i32,
+            pixels_from_left - horizontal_offset.cast_signed(),
             pixels_from_top + vertical_offset,
             font_bundle.scale,
-            font_bundle.font,
+            &font_bundle.font,
             line,
         );
         if cfg!(debug_assertions) {
-            println!("pixels_from_left for line {}: {}", line, pixels_from_left);
+            println!("pixels_from_left for line {line}: {pixels_from_left}");
         }
-        current_line += 1;
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -7,11 +7,11 @@
 use std::fmt::Display;
 
 use ab_glyph::{Font, ScaleFont};
-use image::{DynamicImage, ImageError};
+use image::ImageError;
 use imageproc::drawing::{draw_text_mut, text_size};
 
 pub use ab_glyph::{FontRef, PxScale};
-pub use image::{Rgba, open};
+pub use image::{DynamicImage, Rgba, open};
 
 #[derive(Debug)]
 pub enum TextOnImageError {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -6,9 +6,12 @@
 
 use std::fmt::Display;
 
-use ab_glyph::{Font, FontRef, PxScale, ScaleFont};
-use image::{DynamicImage, ImageError, Rgba};
+use ab_glyph::{Font, ScaleFont};
+use image::{DynamicImage, ImageError};
 use imageproc::drawing::{draw_text_mut, text_size};
+
+pub use ab_glyph::{FontRef, PxScale};
+pub use image::Rgba;
 
 #[derive(Debug)]
 pub enum TextOnImageError {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -96,6 +96,17 @@ impl<'a> FontBundle<'a> {
     pub fn set_color(&mut self, color_: Rgba<u8>) {
         self.color = color_;
     }
+
+    /// Helper function to get text width.
+    pub fn text_width<T: AsRef<str>>(&self, text: T) -> u32 {
+        text_size(self.scale, &self.font, text.as_ref()).0
+    }
+
+    /// Helper function to get text height.
+    pub fn text_height(&self) -> i32 {
+        let scaled_font = self.font.as_scaled(self.scale);
+        (scaled_font.ascent() - scaled_font.descent() + scaled_font.line_gap()) as i32
+    }
 }
 
 #[allow(clippy::too_many_arguments)]
@@ -127,26 +138,26 @@ pub fn text_on_image<T: AsRef<str>>(
         ),
         WrapBehavior::Wrap(max_width) => {
             assert!(
-                (max_width >= &get_text_width(font_bundle, "mm")),
+                (max_width >= &font_bundle.text_width("mm")),
                 "text_on_image: Cannot set max_width for wrapping below 2 ems! Try setting max_width to at least {}",
-                get_text_width(font_bundle, "mm")
+                font_bundle.text_width("mm")
             );
             let mut lines_altered: Vec<String> = vec![];
             for &line in &lines {
                 let mut buffer: String = String::new();
                 for word in line.split_whitespace() {
                     let buffer_copy = buffer.clone();
-                    let buffer_width = get_text_width(font_bundle, buffer_copy.as_str());
+                    let buffer_width = font_bundle.text_width(buffer_copy.as_str());
                     let space_word = String::from(" ") + word;
                     let buffer_space_word_width =
-                        buffer_width + get_text_width(font_bundle, space_word.as_str());
+                        buffer_width + font_bundle.text_width(space_word.as_str());
                     if cfg!(debug_assertions) {
                         println!(
                             "\"{buffer_copy} {word}\" has width {buffer_space_word_width}. Compare to max_width {max_width}"
                         );
                     }
                     let optional_space_width: u32 = if buffer.is_empty() {
-                        get_text_width(font_bundle, " ")
+                        font_bundle.text_width(" ")
                     } else {
                         0
                     };
@@ -164,8 +175,8 @@ pub fn text_on_image<T: AsRef<str>>(
                         // Add partial word with a dash at the end
                         let word_chars = word.chars();
                         for word_char in word_chars {
-                            if (get_text_width(font_bundle, buffer.as_str())
-                                + get_text_width(font_bundle, "-"))
+                            if (font_bundle.text_width(buffer.as_str())
+                                + font_bundle.text_width("-"))
                                 <= *max_width
                             {
                                 buffer.push(word_char);
@@ -184,8 +195,8 @@ pub fn text_on_image<T: AsRef<str>>(
                         buffer = String::new();
                         let word_chars = word.chars();
                         for word_char in word_chars {
-                            if (get_text_width(font_bundle, buffer.as_str())
-                                + get_text_width(font_bundle, "-"))
+                            if (font_bundle.text_width(buffer.as_str())
+                                + font_bundle.text_width("-"))
                                 <= *max_width
                             {
                                 buffer.push(word_char);
@@ -214,17 +225,6 @@ pub fn text_on_image<T: AsRef<str>>(
             );
         }
     }
-}
-
-/// Helper function to get text width.
-fn get_text_width<T: AsRef<str>>(font_bundle: &FontBundle, text: T) -> u32 {
-    text_size(font_bundle.scale, &font_bundle.font, text.as_ref()).0
-}
-
-/// Helper function to get text height.
-fn get_text_height(font_bundle: &FontBundle) -> i32 {
-    let scaled_font = font_bundle.font.as_scaled(font_bundle.scale);
-    (scaled_font.ascent() - scaled_font.descent() + scaled_font.line_gap()) as i32
 }
 
 #[allow(clippy::too_many_arguments)]
@@ -269,22 +269,22 @@ fn position_and_draw(
     let lines_len = lines.len().cast_signed() as i32;
     for (i, &line) in lines.iter().enumerate() {
         if cfg!(debug_assertions) {
-            println!("{line} width: {}", get_text_width(font_bundle, line));
+            println!("{line} width: {}", font_bundle.text_width(line));
         }
         let current_line = i.cast_signed() as i32;
         let vertical_offset: i32 = match vertical_anchor {
-            VerticalAnchor::Top => get_text_height(font_bundle) * current_line,
+            VerticalAnchor::Top => font_bundle.text_height() * current_line,
             VerticalAnchor::Center => {
-                (get_text_height(font_bundle) * current_line
-                    - get_text_height(font_bundle) * (lines_len - current_line))
+                (font_bundle.text_height() * current_line
+                    - font_bundle.text_height() * (lines_len - current_line))
                     / 2
             }
-            VerticalAnchor::Bottom => -(get_text_height(font_bundle) * (lines_len - current_line)),
+            VerticalAnchor::Bottom => -(font_bundle.text_height() * (lines_len - current_line)),
         };
         let horizontal_offset = match horizontal_justify {
             TextJustify::Left => 0,
-            TextJustify::Center => get_text_width(font_bundle, line) / 2,
-            TextJustify::Right => get_text_width(font_bundle, line),
+            TextJustify::Center => font_bundle.text_width(line) / 2,
+            TextJustify::Right => font_bundle.text_width(line),
         };
         draw_text_mut(
             image,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -190,6 +190,7 @@ pub fn text_on_image<T: AsRef<str>>(
                             {
                                 buffer.push(word_char);
                             } else {
+                                buffer.push('-');
                                 lines_altered.push(buffer);
                                 buffer = String::new();
                             }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,7 +2,7 @@
 #![allow(clippy::must_use_candidate)]
 #![allow(clippy::cast_possible_truncation)]
 
-//! A library to make placing text on images easier. Extends the functionality of the [draw_text_mut](https://docs.rs/imageproc/0.23.0/imageproc/drawing/fn.draw_text_mut.html) function from [imageproc](https://docs.rs/imageproc/0.23.0/imageproc/index.html).
+//! A library to make placing text on images easier. Extends the functionality of the [draw_text_mut](https://docs.rs/imageproc/latest/imageproc/drawing/fn.draw_text_mut.html) function from [imageproc](https://docs.rs/imageproc/latest/imageproc/index.html).
 
 use std::fmt::Display;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,5 +1,4 @@
 #![warn(clippy::pedantic)]
-#![allow(clippy::must_use_candidate)]
 #![allow(clippy::cast_possible_truncation)]
 
 //! A library to make placing text on images easier. Extends the functionality of the [draw_text_mut](https://docs.rs/imageproc/latest/imageproc/drawing/fn.draw_text_mut.html) function from [imageproc](https://docs.rs/imageproc/latest/imageproc/index.html).
@@ -44,6 +43,7 @@ pub enum WrapBehavior {
     Wrap(u32),
 }
 impl WrapBehavior {
+    #[must_use]
     pub fn new(max_width: u32) -> Self {
         WrapBehavior::Wrap(max_width)
     }
@@ -70,6 +70,7 @@ impl<'a> FontBundle<'a> {
     /// # Panics
     ///
     /// Will panic if [`FontBundle`] `scale.x` or `scale.y` is negative
+    #[must_use]
     pub fn new(font_: &'a FontRef<'a>, scale_: PxScale, color_: Rgba<u8>) -> Self {
         assert!(
             !(scale_.x <= 0. || scale_.y <= 0.),
@@ -98,11 +99,13 @@ impl<'a> FontBundle<'a> {
     }
 
     /// Helper function to get text width.
+    #[must_use]
     pub fn text_width<T: AsRef<str>>(&self, text: T) -> u32 {
         text_size(self.scale, &self.font, text.as_ref()).0
     }
 
     /// Helper function to get text height.
+    #[must_use]
     pub fn text_height(&self) -> i32 {
         let scaled_font = self.font.as_scaled(self.scale);
         (scaled_font.ascent() - scaled_font.descent() + scaled_font.line_gap()) as i32

--- a/src/test.rs
+++ b/src/test.rs
@@ -1,7 +1,8 @@
 use crate::*;
+use ab_glyph::{FontRef, PxScale};
 use image::{ImageError, Rgba};
-use rusttype::{Font, Scale};
 
+#[allow(dead_code)]
 #[derive(Debug)]
 enum PossibleErrors {
     ImageOpeningError(ImageError),
@@ -12,12 +13,11 @@ const FONT: &[u8] = include_bytes!("../assets/BitstreamVeraSansMonoBold-pq1a.ttf
 
 #[test]
 fn test_example_text() -> Result<(), PossibleErrors> {
-    let mut background = image::open("assets/background.png")
-        .map_err(|err| PossibleErrors::ImageOpeningError(err))?;
+    let mut background =
+        image::open("assets/background.png").map_err(PossibleErrors::ImageOpeningError)?;
     //Set up font
-    let font = Vec::from(FONT);
-    let font = Font::try_from_vec(font).unwrap();
-    let font_bundle = FontBundle::new(&font, Scale { x: 40., y: 40. }, Rgba([0, 255, 0, 255]));
+    let font = FontRef::try_from_slice(FONT).unwrap();
+    let font_bundle = FontBundle::new(&font, PxScale { x: 40., y: 40. }, Rgba([0, 255, 0, 255]));
     //draw on image
     text_on_image_draw_debug(
         &mut background,
@@ -26,21 +26,20 @@ fn test_example_text() -> Result<(), PossibleErrors> {
         &font_bundle,
         400,
         800,
-        TextJustify::Center,
-        VerticalAnchor::Center,
-        WrapBehavior::Wrap(250),
+        &TextJustify::Center,
+        &VerticalAnchor::Center,
+        &WrapBehavior::Wrap(250),
     );
     //save image
     background
         .save("./output/test_example_text.png")
-        .map_err(|err| PossibleErrors::ImageSaveFailure(err))?;
+        .map_err(PossibleErrors::ImageSaveFailure)?;
     Ok(())
 }
 
 #[test]
-#[should_panic]
+#[should_panic = "scale.x or scale.y cannot be <= 0.0"]
 fn test_negative_scale() {
-    let font = Vec::from(FONT);
-    let font = Font::try_from_vec(font).unwrap();
-    let _font_bundle = FontBundle::new(&font, Scale { x: -40., y: 40. }, Rgba([0, 255, 0, 255]));
+    let font = FontRef::try_from_slice(FONT).unwrap();
+    let _font_bundle = FontBundle::new(&font, PxScale { x: -40., y: 40. }, Rgba([0, 255, 0, 255]));
 }


### PR DESCRIPTION
rusttype has been [unmaintained/deprecated](https://rustsec.org/advisories/RUSTSEC-2021-0140.html) for quite a while now, and this crate is using a very old version of image-rs too.

- This PR migrates text_on_image to ab_glyph, which is the recommended replacement for rusttype.
- I also migrated the crate to Rust 2024 and updated all dependencies (image/imageproc).
- I used Clippy pedantic filters to clean up the code a bit.
- Finally, I re-exported several types and a function to improve the API, allowing text_on_image to be used straight out of the box, without needing to add other dependencies.

I'm using my fork for now, but I've found this crate to be pretty handy for simple text on image (imagine that!) so I figured I would push this back upstream. As far as I can tell, everything seems to work fine, but my use case is quite limited so I might have missed something in testing.